### PR TITLE
Java 11 compatibility

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="14" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="true" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
   testImplementation 'junit:junit:4.13'
 }
 
+sourceCompatibility = targetCompatibility = 11
+
 jar {
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 

--- a/src/main/java/com/whitemagicsoftware/tex/boxes/HorizontalBox.java
+++ b/src/main/java/com/whitemagicsoftware/tex/boxes/HorizontalBox.java
@@ -54,20 +54,22 @@ public final class HorizontalBox extends Box {
   public HorizontalBox( final Box b, final float w, final int alignment ) {
     final float rest = w - b.getWidth();
     switch( alignment ) {
-      case TeXConstants.ALIGN_CENTER -> {
+      case TeXConstants.ALIGN_CENTER:
         final var s = new StrutBox( rest / 2 );
         add( s );
         add( b );
         add( s );
-      }
-      case TeXConstants.ALIGN_LEFT -> {
+        break;
+
+      case TeXConstants.ALIGN_LEFT:
         add( b );
         add( new StrutBox( rest ) );
-      }
-      case TeXConstants.ALIGN_RIGHT -> {
+        break;
+
+      case TeXConstants.ALIGN_RIGHT:
         add( new StrutBox( rest ) );
         add( b );
-      }
+        break;
     }
   }
 

--- a/src/main/java/com/whitemagicsoftware/tex/boxes/VerticalBox.java
+++ b/src/main/java/com/whitemagicsoftware/tex/boxes/VerticalBox.java
@@ -50,21 +50,23 @@ public class VerticalBox extends Box {
     this();
     add( b );
     switch( alignment ) {
-      case TeXConstants.ALIGN_CENTER -> {
+      case TeXConstants.ALIGN_CENTER:
         final StrutBox s = new StrutBox( 0, rest / 2, 0, 0 );
         super.add( 0, s );
         height += rest / 2;
         depth += rest / 2;
         super.add( s );
-      }
-      case TeXConstants.ALIGN_TOP -> {
+        break;
+
+      case TeXConstants.ALIGN_TOP:
         depth += rest;
         super.add( new StrutBox( 0, rest, 0, 0 ) );
-      }
-      case TeXConstants.ALIGN_BOTTOM -> {
+        break;
+
+      case TeXConstants.ALIGN_BOTTOM:
         height += rest;
         super.add( 0, new StrutBox( 0, rest, 0, 0 ) );
-      }
+        break;
     }
   }
 

--- a/src/main/java/com/whitemagicsoftware/tex/graphics/SvgDomGraphics2D.java
+++ b/src/main/java/com/whitemagicsoftware/tex/graphics/SvgDomGraphics2D.java
@@ -197,35 +197,45 @@ public final class SvgDomGraphics2D extends AbstractGraphics2D {
 
     while( !iterator.isDone() ) {
       switch( iterator.currentSegment( mCoords ) ) {
-        case 0 -> sData.append( 'M' )
-                       .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 1 ] ) );
-        case 1 -> sData.append( 'L' )
-                       .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 1 ] ) );
-        case 2 -> sData.append( 'Q' )
-                       .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 1 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 2 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 3 ] ) );
-        case 3 -> sData.append( 'C' )
-                       .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 1 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 2 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 3 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 4 ] ) )
-                       .append( ' ' )
-                       .append( toGeometryPrecision( mCoords[ 5 ] ) );
-        case 4 -> sData.append( 'Z' );
+        case 0:
+          sData.append( 'M' )
+               .append( toGeometryPrecision( mCoords[ 0 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 1 ] ) );
+          break;
+        case 1:
+          sData.append( 'L' )
+               .append( toGeometryPrecision( mCoords[ 0 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 1 ] ) );
+          break;
+        case 2:
+          sData.append( 'Q' )
+               .append( toGeometryPrecision( mCoords[ 0 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 1 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 2 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 3 ] ) );
+          break;
+        case 3:
+          sData.append( 'C' )
+               .append( toGeometryPrecision( mCoords[ 0 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 1 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 2 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 3 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 4 ] ) )
+               .append( ' ' )
+               .append( toGeometryPrecision( mCoords[ 5 ] ) );
+          break;
+        case 4:
+          sData.append( 'Z' );
+          break;
       }
 
       iterator.next();

--- a/src/main/java/com/whitemagicsoftware/tex/graphics/SvgGraphics2D.java
+++ b/src/main/java/com/whitemagicsoftware/tex/graphics/SvgGraphics2D.java
@@ -146,35 +146,45 @@ public final class SvgGraphics2D extends AbstractGraphics2D {
 
     while( !iterator.isDone() ) {
       switch( iterator.currentSegment( mCoords ) ) {
-        case 0 -> mSvg.append( 'M' )
-                      .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 1 ] ) );
-        case 1 -> mSvg.append( 'L' )
-                      .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 1 ] ) );
-        case 2 -> mSvg.append( 'Q' )
-                      .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 1 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 2 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 3 ] ) );
-        case 3 -> mSvg.append( 'C' )
-                      .append( toGeometryPrecision( mCoords[ 0 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 1 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 2 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 3 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 4 ] ) )
-                      .append( ' ' )
-                      .append( toGeometryPrecision( mCoords[ 5 ] ) );
-        case 4 -> mSvg.append( 'Z' );
+        case 0:
+          mSvg.append( 'M' )
+              .append( toGeometryPrecision( mCoords[ 0 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 1 ] ) );
+          break;
+        case 1:
+          mSvg.append( 'L' )
+              .append( toGeometryPrecision( mCoords[ 0 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 1 ] ) );
+          break;
+        case 2:
+          mSvg.append( 'Q' )
+              .append( toGeometryPrecision( mCoords[ 0 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 1 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 2 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 3 ] ) );
+          break;
+        case 3:
+          mSvg.append( 'C' )
+              .append( toGeometryPrecision( mCoords[ 0 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 1 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 2 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 3 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 4 ] ) )
+              .append( ' ' )
+              .append( toGeometryPrecision( mCoords[ 5 ] ) );
+          break;
+        case 4:
+          mSvg.append( 'Z' );
+          break;
       }
 
       iterator.next();


### PR DESCRIPTION
The reason this codebase currently isn't compatible with Java 11 (the current LTS) is the use of the fancy new expression-switches.
However, the expression-part of this syntax is never used, a 'classic' break-style switch works just fine.

This PR transforms all 'offending' switches to the classic syntax, making this project compatible with Java 11.