### PR TITLE
Add jitpack configuration for Java 11 toolchain

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11


### PR DESCRIPTION
As far as I can tell this library is not available through a repository like Maven Central, which makes it less convenient to use.
An easy solution to this could be using [jitpack.io](https://jitpack.io/#DaveJarvis/JMathTeX), which allows using a github repository as gradle dependency.

Unfortunately jitpack builds projects with Java 8 by default, while this project requires Java 11.
This can be fixed by adding a small [config file](https://jitpack.io/docs/BUILDING/#java-version), this PR adds that file.

I think publishing this library to something like Maven Central would be the best solution, but I understand that this comes with extra maintenance effort. Adding this file could save that, while also making it much more convenient to use this library.